### PR TITLE
[TT-16932] Cherry pick for pgx v5

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -39,4 +39,8 @@ var (
 	ErrInvalidValue = errors.New("invalid value, should be pointer to struct or slice")
 	// ErrInvalidValueOfLength invalid values do not match length
 	ErrInvalidValueOfLength = errors.New("invalid association values, length doesn't match")
+	// ErrPreloadNotAllowed preload is not allowed when count is used
+	ErrPreloadNotAllowed = errors.New("preload is not allowed when count is used")
+	// ErrDuplicatedKey occurs when there is a unique key constraint violation
+	ErrDuplicatedKey = errors.New("duplicated key not allowed")
 )

--- a/finisher_api.go
+++ b/finisher_api.go
@@ -512,6 +512,30 @@ func (db *DB) ScanRows(rows *sql.Rows, dest interface{}) error {
 	return tx.Error
 }
 
+// Connection  use a db conn to execute Multiple commands,this conn will put conn pool after it is executed.
+func (db *DB) Connection(fc func(tx *DB) error) (err error) {
+	if db.Error != nil {
+		return db.Error
+	}
+
+	tx := db.getInstance()
+	sqlDB, err := tx.DB()
+	if err != nil {
+		return
+	}
+
+	conn, err := sqlDB.Conn(tx.Statement.Context)
+	if err != nil {
+		return
+	}
+
+	defer conn.Close()
+	tx.Statement.ConnPool = conn
+	err = fc(tx)
+
+	return
+}
+
 // Transaction start a transaction as a block, return error will rollback, otherwise to commit.
 func (db *DB) Transaction(fc func(tx *DB) error, opts ...*sql.TxOptions) (err error) {
 	panicked := true

--- a/gorm.go
+++ b/gorm.go
@@ -335,6 +335,10 @@ func (db *DB) Callback() *callbacks {
 
 // AddError add error to db
 func (db *DB) AddError(err error) error {
+	if errTranslator, ok := db.Dialector.(ErrorTranslator); ok {
+		err = errTranslator.Translate(err)
+	}
+
 	if db.Error == nil {
 		db.Error = err
 	} else if err != nil {

--- a/interfaces.go
+++ b/interfaces.go
@@ -61,3 +61,17 @@ type Valuer interface {
 type GetDBConnector interface {
 	GetDBConn() (*sql.DB, error)
 }
+
+// Rows rows interface
+type Rows interface {
+	Columns() ([]string, error)
+	ColumnTypes() ([]*sql.ColumnType, error)
+	Next() bool
+	Scan(dest ...interface{}) error
+	Err() error
+	Close() error
+}
+
+type ErrorTranslator interface {
+	Translate(err error) error
+}

--- a/migrator.go
+++ b/migrator.go
@@ -1,6 +1,8 @@
 package gorm
 
 import (
+	"reflect"
+
 	"gorm.io/gorm/clause"
 	"gorm.io/gorm/schema"
 )
@@ -33,14 +35,23 @@ type ViewOption struct {
 	Query       *DB
 }
 
+// ColumnType column type interface
 type ColumnType interface {
 	Name() string
-	DatabaseTypeName() string
+	DatabaseTypeName() string                 // varchar
+	ColumnType() (columnType string, ok bool) // varchar(64)
+	PrimaryKey() (isPrimaryKey bool, ok bool)
+	AutoIncrement() (isAutoIncrement bool, ok bool)
 	Length() (length int64, ok bool)
 	DecimalSize() (precision int64, scale int64, ok bool)
 	Nullable() (nullable bool, ok bool)
+	Unique() (unique bool, ok bool)
+	ScanType() reflect.Type
+	Comment() (value string, ok bool)
+	DefaultValue() (value string, ok bool)
 }
 
+// Migrator migrator interface
 type Migrator interface {
 	// AutoMigrate
 	AutoMigrate(dst ...interface{}) error

--- a/migrator.go
+++ b/migrator.go
@@ -51,6 +51,15 @@ type ColumnType interface {
 	DefaultValue() (value string, ok bool)
 }
 
+type Index interface {
+	Table() string
+	Name() string
+	Columns() []string
+	PrimaryKey() (isPrimaryKey bool, ok bool)
+	Unique() (unique bool, ok bool)
+	Option() string
+}
+
 // Migrator migrator interface
 type Migrator interface {
 	// AutoMigrate
@@ -89,4 +98,5 @@ type Migrator interface {
 	DropIndex(dst interface{}, name string) error
 	HasIndex(dst interface{}, name string) bool
 	RenameIndex(dst interface{}, oldName, newName string) error
+	GetIndexes(dst interface{}) ([]Index, error)
 }

--- a/migrator/column_type.go
+++ b/migrator/column_type.go
@@ -11,7 +11,7 @@ type ColumnType struct {
 	NameValue          sql.NullString
 	DataTypeValue      sql.NullString
 	ColumnTypeValue    sql.NullString
-	PrimayKeyValue     sql.NullBool
+	PrimaryKeyValue    sql.NullBool
 	UniqueValue        sql.NullBool
 	AutoIncrementValue sql.NullBool
 	LengthValue        sql.NullInt64
@@ -51,7 +51,7 @@ func (ct ColumnType) ColumnType() (columnType string, ok bool) {
 
 // PrimaryKey returns the column is primary key or not.
 func (ct ColumnType) PrimaryKey() (isPrimaryKey bool, ok bool) {
-	return ct.PrimayKeyValue.Bool, ct.PrimayKeyValue.Valid
+	return ct.PrimaryKeyValue.Bool, ct.PrimaryKeyValue.Valid
 }
 
 // AutoIncrement returns the column is auto increment or not.

--- a/migrator/column_type.go
+++ b/migrator/column_type.go
@@ -1,0 +1,107 @@
+package migrator
+
+import (
+	"database/sql"
+	"reflect"
+)
+
+// ColumnType column type implements ColumnType interface
+type ColumnType struct {
+	SQLColumnType      *sql.ColumnType
+	NameValue          sql.NullString
+	DataTypeValue      sql.NullString
+	ColumnTypeValue    sql.NullString
+	PrimayKeyValue     sql.NullBool
+	UniqueValue        sql.NullBool
+	AutoIncrementValue sql.NullBool
+	LengthValue        sql.NullInt64
+	DecimalSizeValue   sql.NullInt64
+	ScaleValue         sql.NullInt64
+	NullableValue      sql.NullBool
+	ScanTypeValue      reflect.Type
+	CommentValue       sql.NullString
+	DefaultValueValue  sql.NullString
+}
+
+// Name returns the name or alias of the column.
+func (ct ColumnType) Name() string {
+	if ct.NameValue.Valid {
+		return ct.NameValue.String
+	}
+	return ct.SQLColumnType.Name()
+}
+
+// DatabaseTypeName returns the database system name of the column type. If an empty
+// string is returned, then the driver type name is not supported.
+// Consult your driver documentation for a list of driver data types. Length specifiers
+// are not included.
+// Common type names include "VARCHAR", "TEXT", "NVARCHAR", "DECIMAL", "BOOL",
+// "INT", and "BIGINT".
+func (ct ColumnType) DatabaseTypeName() string {
+	if ct.DataTypeValue.Valid {
+		return ct.DataTypeValue.String
+	}
+	return ct.SQLColumnType.DatabaseTypeName()
+}
+
+// ColumnType returns the database type of the column. lke `varchar(16)`
+func (ct ColumnType) ColumnType() (columnType string, ok bool) {
+	return ct.ColumnTypeValue.String, ct.ColumnTypeValue.Valid
+}
+
+// PrimaryKey returns the column is primary key or not.
+func (ct ColumnType) PrimaryKey() (isPrimaryKey bool, ok bool) {
+	return ct.PrimayKeyValue.Bool, ct.PrimayKeyValue.Valid
+}
+
+// AutoIncrement returns the column is auto increment or not.
+func (ct ColumnType) AutoIncrement() (isAutoIncrement bool, ok bool) {
+	return ct.AutoIncrementValue.Bool, ct.AutoIncrementValue.Valid
+}
+
+// Length returns the column type length for variable length column types
+func (ct ColumnType) Length() (length int64, ok bool) {
+	if ct.LengthValue.Valid {
+		return ct.LengthValue.Int64, true
+	}
+	return ct.SQLColumnType.Length()
+}
+
+// DecimalSize returns the scale and precision of a decimal type.
+func (ct ColumnType) DecimalSize() (precision int64, scale int64, ok bool) {
+	if ct.DecimalSizeValue.Valid {
+		return ct.DecimalSizeValue.Int64, ct.ScaleValue.Int64, true
+	}
+	return ct.SQLColumnType.DecimalSize()
+}
+
+// Nullable reports whether the column may be null.
+func (ct ColumnType) Nullable() (nullable bool, ok bool) {
+	if ct.NullableValue.Valid {
+		return ct.NullableValue.Bool, true
+	}
+	return ct.SQLColumnType.Nullable()
+}
+
+// Unique reports whether the column may be unique.
+func (ct ColumnType) Unique() (unique bool, ok bool) {
+	return ct.UniqueValue.Bool, ct.UniqueValue.Valid
+}
+
+// ScanType returns a Go type suitable for scanning into using Rows.Scan.
+func (ct ColumnType) ScanType() reflect.Type {
+	if ct.ScanTypeValue != nil {
+		return ct.ScanTypeValue
+	}
+	return ct.SQLColumnType.ScanType()
+}
+
+// Comment returns the comment of current column.
+func (ct ColumnType) Comment() (value string, ok bool) {
+	return ct.CommentValue.String, ct.CommentValue.Valid
+}
+
+// DefaultValue returns the default value of current column.
+func (ct ColumnType) DefaultValue() (value string, ok bool) {
+	return ct.DefaultValueValue.String, ct.DefaultValueValue.Valid
+}

--- a/migrator/index.go
+++ b/migrator/index.go
@@ -1,0 +1,43 @@
+package migrator
+
+import "database/sql"
+
+// Index implements gorm.Index interface
+type Index struct {
+	TableName       string
+	NameValue       string
+	ColumnList      []string
+	PrimaryKeyValue sql.NullBool
+	UniqueValue     sql.NullBool
+	OptionValue     string
+}
+
+// Table return the table name of the index.
+func (idx Index) Table() string {
+	return idx.TableName
+}
+
+// Name return the name  of the index.
+func (idx Index) Name() string {
+	return idx.NameValue
+}
+
+// Columns return the columns fo the index
+func (idx Index) Columns() []string {
+	return idx.ColumnList
+}
+
+// PrimaryKey returns the index is primary key or not.
+func (idx Index) PrimaryKey() (isPrimaryKey bool, ok bool) {
+	return idx.PrimaryKeyValue.Bool, idx.PrimaryKeyValue.Valid
+}
+
+// Unique returns whether the index is unique or not.
+func (idx Index) Unique() (unique bool, ok bool) {
+	return idx.UniqueValue.Bool, idx.UniqueValue.Valid
+}
+
+// Option return the optional attribute fo the index
+func (idx Index) Option() string {
+	return idx.OptionValue
+}

--- a/migrator/migrator.go
+++ b/migrator/migrator.go
@@ -30,10 +30,12 @@ type Config struct {
 	gorm.Dialector
 }
 
+// GormDataTypeInterface gorm data type interface
 type GormDataTypeInterface interface {
 	GormDBDataType(*gorm.DB, *schema.Field) string
 }
 
+// RunWithValue run migration with statement value
 func (m Migrator) RunWithValue(value interface{}, fc func(*gorm.Statement) error) error {
 	stmt := &gorm.Statement{DB: m.DB}
 	if m.DB.Statement != nil {
@@ -50,6 +52,7 @@ func (m Migrator) RunWithValue(value interface{}, fc func(*gorm.Statement) error
 	return fc(stmt)
 }
 
+// DataTypeOf return field's db data type
 func (m Migrator) DataTypeOf(field *schema.Field) string {
 	fieldValue := reflect.New(field.IndirectFieldType)
 	if dataTyper, ok := fieldValue.Interface().(GormDataTypeInterface); ok {
@@ -67,6 +70,7 @@ func (m Migrator) DataTypeOf(field *schema.Field) string {
 	return m.Dialector.DataTypeOf(field)
 }
 
+// FullDataTypeOf returns field's db full data type
 func (m Migrator) FullDataTypeOf(field *schema.Field) (expr clause.Expr) {
 	expr.SQL = m.DataTypeOf(field)
 
@@ -91,7 +95,7 @@ func (m Migrator) FullDataTypeOf(field *schema.Field) (expr clause.Expr) {
 	return
 }
 
-// AutoMigrate
+// AutoMigrate auto migrate values
 func (m Migrator) AutoMigrate(values ...interface{}) error {
 	for _, value := range m.ReorderModels(values, true) {
 		tx := m.DB.Session(&gorm.Session{})
@@ -161,6 +165,14 @@ func (m Migrator) AutoMigrate(values ...interface{}) error {
 	return nil
 }
 
+// GetTables returns tables
+func (m Migrator) GetTables() (tableList []string, err error) {
+	err = m.DB.Raw("SELECT TABLE_NAME FROM information_schema.tables where TABLE_SCHEMA=?", m.CurrentDatabase()).
+		Scan(&tableList).Error
+	return
+}
+
+// CreateTable create table in database for values
 func (m Migrator) CreateTable(values ...interface{}) error {
 	for _, value := range m.ReorderModels(values, false) {
 		tx := m.DB.Session(&gorm.Session{})
@@ -251,6 +263,7 @@ func (m Migrator) CreateTable(values ...interface{}) error {
 	return nil
 }
 
+// DropTable drop table for values
 func (m Migrator) DropTable(values ...interface{}) error {
 	values = m.ReorderModels(values, false)
 	for i := len(values) - 1; i >= 0; i-- {
@@ -264,6 +277,7 @@ func (m Migrator) DropTable(values ...interface{}) error {
 	return nil
 }
 
+// HasTable returns table exists or not for value, value could be a struct or string
 func (m Migrator) HasTable(value interface{}) bool {
 	var count int64
 
@@ -275,6 +289,7 @@ func (m Migrator) HasTable(value interface{}) bool {
 	return count > 0
 }
 
+// RenameTable rename table from oldName to newName
 func (m Migrator) RenameTable(oldName, newName interface{}) error {
 	var oldTable, newTable interface{}
 	if v, ok := oldName.(string); ok {
@@ -302,12 +317,13 @@ func (m Migrator) RenameTable(oldName, newName interface{}) error {
 	return m.DB.Exec("ALTER TABLE ? RENAME TO ?", oldTable, newTable).Error
 }
 
-func (m Migrator) AddColumn(value interface{}, field string) error {
+// AddColumn create `name` column for value
+func (m Migrator) AddColumn(value interface{}, name string) error {
 	return m.RunWithValue(value, func(stmt *gorm.Statement) error {
 		// avoid using the same name field
-		f := stmt.Schema.LookUpField(field)
+		f := stmt.Schema.LookUpField(name)
 		if f == nil {
-			return fmt.Errorf("failed to look up field with name: %s", field)
+			return fmt.Errorf("failed to look up field with name: %s", name)
 		}
 
 		if !f.IgnoreMigration {
@@ -321,6 +337,7 @@ func (m Migrator) AddColumn(value interface{}, field string) error {
 	})
 }
 
+// DropColumn drop value's `name` column
 func (m Migrator) DropColumn(value interface{}, name string) error {
 	return m.RunWithValue(value, func(stmt *gorm.Statement) error {
 		if field := stmt.Schema.LookUpField(name); field != nil {
@@ -333,6 +350,7 @@ func (m Migrator) DropColumn(value interface{}, name string) error {
 	})
 }
 
+// AlterColumn alter value's `field` column' type based on schema definition
 func (m Migrator) AlterColumn(value interface{}, field string) error {
 	return m.RunWithValue(value, func(stmt *gorm.Statement) error {
 		if field := stmt.Schema.LookUpField(field); field != nil {
@@ -347,6 +365,7 @@ func (m Migrator) AlterColumn(value interface{}, field string) error {
 	})
 }
 
+// HasColumn check has column `field` for value or not
 func (m Migrator) HasColumn(value interface{}, field string) bool {
 	var count int64
 	m.RunWithValue(value, func(stmt *gorm.Statement) error {
@@ -365,6 +384,7 @@ func (m Migrator) HasColumn(value interface{}, field string) bool {
 	return count > 0
 }
 
+// RenameColumn rename value's field name from oldName to newName
 func (m Migrator) RenameColumn(value interface{}, oldName, newName string) error {
 	return m.RunWithValue(value, func(stmt *gorm.Statement) error {
 		if field := stmt.Schema.LookUpField(oldName); field != nil {
@@ -382,6 +402,7 @@ func (m Migrator) RenameColumn(value interface{}, oldName, newName string) error
 	})
 }
 
+// MigrateColumn migrate column
 func (m Migrator) MigrateColumn(value interface{}, field *schema.Field, columnType gorm.ColumnType) error {
 	// found, smart migrate
 	fullDataType := strings.ToLower(m.DB.Migrator().FullDataTypeOf(field).SQL)
@@ -445,7 +466,7 @@ func (m Migrator) ColumnTypes(value interface{}) ([]gorm.ColumnType, error) {
 		}
 
 		for _, c := range rawColumnTypes {
-			columnTypes = append(columnTypes, c)
+			columnTypes = append(columnTypes, ColumnType{SQLColumnType: c})
 		}
 
 		return nil
@@ -454,10 +475,12 @@ func (m Migrator) ColumnTypes(value interface{}) ([]gorm.ColumnType, error) {
 	return columnTypes, execErr
 }
 
+// CreateView create view
 func (m Migrator) CreateView(name string, option gorm.ViewOption) error {
 	return gorm.ErrNotImplemented
 }
 
+// DropView drop view
 func (m Migrator) DropView(name string) error {
 	return gorm.ErrNotImplemented
 }
@@ -484,6 +507,7 @@ func buildConstraint(constraint *schema.Constraint) (sql string, results []inter
 	return
 }
 
+// GuessConstraintAndTable guess statement's constraint and it's table based on name
 func (m Migrator) GuessConstraintAndTable(stmt *gorm.Statement, name string) (_ *schema.Constraint, _ *schema.Check, table string) {
 	if stmt.Schema == nil {
 		return nil, nil, stmt.Table
@@ -528,6 +552,7 @@ func (m Migrator) GuessConstraintAndTable(stmt *gorm.Statement, name string) (_ 
 	return nil, nil, stmt.Schema.Table
 }
 
+// CreateConstraint create constraint
 func (m Migrator) CreateConstraint(value interface{}, name string) error {
 	return m.RunWithValue(value, func(stmt *gorm.Statement) error {
 		constraint, chk, table := m.GuessConstraintAndTable(stmt, name)
@@ -551,6 +576,7 @@ func (m Migrator) CreateConstraint(value interface{}, name string) error {
 	})
 }
 
+// DropConstraint drop constraint
 func (m Migrator) DropConstraint(value interface{}, name string) error {
 	return m.RunWithValue(value, func(stmt *gorm.Statement) error {
 		constraint, chk, table := m.GuessConstraintAndTable(stmt, name)
@@ -563,6 +589,7 @@ func (m Migrator) DropConstraint(value interface{}, name string) error {
 	})
 }
 
+// HasConstraint check has constraint or not
 func (m Migrator) HasConstraint(value interface{}, name string) bool {
 	var count int64
 	m.RunWithValue(value, func(stmt *gorm.Statement) error {
@@ -583,6 +610,7 @@ func (m Migrator) HasConstraint(value interface{}, name string) bool {
 	return count > 0
 }
 
+// BuildIndexOptions build index options
 func (m Migrator) BuildIndexOptions(opts []schema.IndexOption, stmt *gorm.Statement) (results []interface{}) {
 	for _, opt := range opts {
 		str := stmt.Quote(opt.DBName)
@@ -604,10 +632,12 @@ func (m Migrator) BuildIndexOptions(opts []schema.IndexOption, stmt *gorm.Statem
 	return
 }
 
+// BuildIndexOptionsInterface build index options interface
 type BuildIndexOptionsInterface interface {
 	BuildIndexOptions([]schema.IndexOption, *gorm.Statement) []interface{}
 }
 
+// CreateIndex create index `name`
 func (m Migrator) CreateIndex(value interface{}, name string) error {
 	return m.RunWithValue(value, func(stmt *gorm.Statement) error {
 		if idx := stmt.Schema.LookIndex(name); idx != nil {
@@ -639,6 +669,7 @@ func (m Migrator) CreateIndex(value interface{}, name string) error {
 	})
 }
 
+// DropIndex drop index `name`
 func (m Migrator) DropIndex(value interface{}, name string) error {
 	return m.RunWithValue(value, func(stmt *gorm.Statement) error {
 		if idx := stmt.Schema.LookIndex(name); idx != nil {
@@ -649,6 +680,7 @@ func (m Migrator) DropIndex(value interface{}, name string) error {
 	})
 }
 
+// HasIndex check has index `name` or not
 func (m Migrator) HasIndex(value interface{}, name string) bool {
 	var count int64
 	m.RunWithValue(value, func(stmt *gorm.Statement) error {
@@ -666,6 +698,7 @@ func (m Migrator) HasIndex(value interface{}, name string) bool {
 	return count > 0
 }
 
+// RenameIndex rename index from oldName to newName
 func (m Migrator) RenameIndex(value interface{}, oldName, newName string) error {
 	return m.RunWithValue(value, func(stmt *gorm.Statement) error {
 		return m.DB.Exec(
@@ -675,6 +708,7 @@ func (m Migrator) RenameIndex(value interface{}, oldName, newName string) error 
 	})
 }
 
+// CurrentDatabase returns current database name
 func (m Migrator) CurrentDatabase() (name string) {
 	m.DB.Raw("SELECT DATABASE()").Row().Scan(&name)
 	return
@@ -778,6 +812,7 @@ func (m Migrator) ReorderModels(values []interface{}, autoAdd bool) (results []i
 	return
 }
 
+// CurrentTable returns current statement's table expression
 func (m Migrator) CurrentTable(stmt *gorm.Statement) interface{} {
 	if stmt.TableExpr != nil {
 		return *stmt.TableExpr

--- a/migrator/migrator.go
+++ b/migrator/migrator.go
@@ -442,6 +442,30 @@ func (m Migrator) MigrateColumn(value interface{}, field *schema.Field, columnTy
 		}
 	}
 
+	// check unique
+	if unique, ok := columnType.Unique(); ok && unique != field.Unique {
+		// not primary key
+		if !field.PrimaryKey {
+			alterColumn = true
+		}
+	}
+
+	// check default value
+	if v, ok := columnType.DefaultValue(); ok && v != field.DefaultValue {
+		// not primary key
+		if !field.PrimaryKey {
+			alterColumn = true
+		}
+	}
+
+	// check comment
+	if comment, ok := columnType.Comment(); ok && comment != field.Comment {
+		// not primary key
+		if !field.PrimaryKey {
+			alterColumn = true
+		}
+	}
+
 	if alterColumn && !field.IgnoreMigration {
 		return m.DB.Migrator().AlterColumn(value, field.Name)
 	}

--- a/migrator/migrator.go
+++ b/migrator/migrator.go
@@ -3,6 +3,7 @@ package migrator
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"reflect"
 	"regexp"
@@ -818,4 +819,9 @@ func (m Migrator) CurrentTable(stmt *gorm.Statement) interface{} {
 		return *stmt.TableExpr
 	}
 	return clause.Table{Name: stmt.Table}
+}
+
+// GetIndexes return Indexes []gorm.Index and execErr error
+func (m Migrator) GetIndexes(dst interface{}) ([]gorm.Index, error) {
+	return nil, errors.New("not support")
 }

--- a/prepare_stmt.go
+++ b/prepare_stmt.go
@@ -42,6 +42,18 @@ func (db *PreparedStmtDB) Close() {
 	db.Mux.Unlock()
 }
 
+func (db *PreparedStmtDB) Reset() {
+	db.Mux.Lock()
+	defer db.Mux.Unlock()
+	for query, stmt := range db.Stmts {
+		delete(db.Stmts, query)
+		go stmt.Close()
+	}
+
+	db.PreparedSQL = make([]string, 0, 100)
+	db.Stmts = map[string]Stmt{}
+}
+
 func (db *PreparedStmtDB) prepare(ctx context.Context, conn ConnPool, isTransaction bool, query string) (Stmt, error) {
 	db.Mux.RLock()
 	if stmt, ok := db.Stmts[query]; ok && (!stmt.Transaction || isTransaction) {

--- a/tests/connection_test.go
+++ b/tests/connection_test.go
@@ -1,0 +1,48 @@
+package tests_test
+
+import (
+	"fmt"
+	"gorm.io/driver/mysql"
+	"gorm.io/gorm"
+	"testing"
+)
+
+func TestWithSingleConnection(t *testing.T) {
+
+	var expectedName = "test"
+	var actualName string
+
+	setSQL, getSQL := getSetSQL(DB.Dialector.Name())
+	if len(setSQL) == 0 || len(getSQL) == 0 {
+		return
+	}
+
+	err := DB.Connection(func(tx *gorm.DB) error {
+		if err := tx.Exec(setSQL, expectedName).Error; err != nil {
+			return err
+		}
+
+		if err := tx.Raw(getSQL).Scan(&actualName).Error; err != nil {
+			return err
+		}
+		return nil
+	})
+
+	if err != nil {
+		t.Errorf(fmt.Sprintf("WithSingleConnection should work, but got err %v", err))
+	}
+
+	if actualName != expectedName {
+		t.Errorf("WithSingleConnection() method should get correct value, expect: %v, got %v", expectedName, actualName)
+	}
+
+}
+
+func getSetSQL(driverName string) (string, string) {
+	switch driverName {
+	case mysql.Dialector{}.Name():
+		return "SET @testName := ?", "SELECT @testName"
+	default:
+		return "", ""
+	}
+}

--- a/tests/error_translator_test.go
+++ b/tests/error_translator_test.go
@@ -1,0 +1,19 @@
+package tests_test
+
+import (
+	"errors"
+	"testing"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/utils/tests"
+)
+
+func TestDialectorWithErrorTranslatorSupport(t *testing.T) {
+	translatedErr := errors.New("translated error")
+	db, _ := gorm.Open(tests.DummyDialector{TranslatedErr: translatedErr})
+
+	err := db.AddError(errors.New("some random error"))
+	if !errors.Is(err, translatedErr) {
+		t.Fatalf("expected err: %v got err: %v", translatedErr, err)
+	}
+}

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -9,11 +9,11 @@ require (
 	github.com/lib/pq v1.10.4
 	github.com/mattn/go-sqlite3 v1.14.11 // indirect
 	golang.org/x/crypto v0.0.0-20220214200702-86341886e292 // indirect
-	gorm.io/driver/mysql v1.3.0
-	gorm.io/driver/postgres v1.3.0
-	gorm.io/driver/sqlite v1.3.0
-	gorm.io/driver/sqlserver v1.3.0
-	gorm.io/gorm v1.22.5
+	gorm.io/driver/mysql v1.3.1
+	gorm.io/driver/postgres v1.3.1
+	gorm.io/driver/sqlite v1.3.1
+	gorm.io/driver/sqlserver v1.3.1
+	gorm.io/gorm v1.23.0
 )
 
 replace gorm.io/gorm => ../

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -4,13 +4,16 @@ go 1.14
 
 require (
 	github.com/google/uuid v1.3.0
-	github.com/jinzhu/now v1.1.2
-	github.com/lib/pq v1.10.2
-	gorm.io/driver/mysql v1.1.2
-	gorm.io/driver/postgres v1.1.0
-	gorm.io/driver/sqlite v1.1.4
-	gorm.io/driver/sqlserver v1.0.8
-	gorm.io/gorm v1.21.14
+	github.com/jackc/pgx/v4 v4.15.0 // indirect
+	github.com/jinzhu/now v1.1.4
+	github.com/lib/pq v1.10.4
+	github.com/mattn/go-sqlite3 v1.14.11 // indirect
+	golang.org/x/crypto v0.0.0-20220214200702-86341886e292 // indirect
+	gorm.io/driver/mysql v1.3.0
+	gorm.io/driver/postgres v1.3.0
+	gorm.io/driver/sqlite v1.3.0
+	gorm.io/driver/sqlserver v1.3.0
+	gorm.io/gorm v1.22.5
 )
 
 replace gorm.io/gorm => ../

--- a/tests/migrate_test.go
+++ b/tests/migrate_test.go
@@ -27,7 +27,7 @@ func TestMigrate(t *testing.T) {
 
 	for _, m := range allModels {
 		if !DB.Migrator().HasTable(m) {
-			t.Fatalf("Failed to create table for %#v---", m)
+			t.Fatalf("Failed to create table for %#v", m)
 		}
 	}
 
@@ -277,15 +277,16 @@ func TestMigrateIndexes(t *testing.T) {
 }
 
 func TestMigrateColumns(t *testing.T) {
-	fullSupported := map[string]bool{"sqlite": true, "mysql": true, "postgres": true, "sqlserver": true}[DB.Dialector.Name()]
 	sqlite := DB.Dialector.Name() == "sqlite"
 	sqlserver := DB.Dialector.Name() == "sqlserver"
 
 	type ColumnStruct struct {
 		gorm.Model
-		Name string
-		Age  int    `gorm:"default:18;comment:my age"`
-		Code string `gorm:"unique"`
+		Name  string
+		Age   int    `gorm:"default:18;comment:my age"`
+		Code  string `gorm:"unique;comment:my code;"`
+		Code2 string
+		Code3 string `gorm:"unique"`
 	}
 
 	DB.Migrator().DropTable(&ColumnStruct{})
@@ -296,11 +297,18 @@ func TestMigrateColumns(t *testing.T) {
 
 	type ColumnStruct2 struct {
 		gorm.Model
-		Name string `gorm:"size:100"`
+		Name  string `gorm:"size:100"`
+		Code  string `gorm:"unique;comment:my code2;default:hello"`
+		Code2 string `gorm:"unique"`
+		// Code3 string
 	}
 
-	if err := DB.Table("column_structs").Migrator().AlterColumn(&ColumnStruct2{}, "Name"); err != nil {
+	if err := DB.Table("column_structs").Migrator().AlterColumn(&ColumnStruct{}, "Name"); err != nil {
 		t.Fatalf("no error should happened when alter column, but got %v", err)
+	}
+
+	if err := DB.Table("column_structs").AutoMigrate(&ColumnStruct2{}); err != nil {
+		t.Fatalf("no error should happened when auto migrate column, but got %v", err)
 	}
 
 	if columnTypes, err := DB.Migrator().ColumnTypes(&ColumnStruct{}); err != nil {
@@ -312,7 +320,7 @@ func TestMigrateColumns(t *testing.T) {
 		for _, columnType := range columnTypes {
 			switch columnType.Name() {
 			case "id":
-				if v, ok := columnType.PrimaryKey(); (fullSupported || ok) && !v {
+				if v, ok := columnType.PrimaryKey(); !ok || !v {
 					t.Fatalf("column id primary key should be correct, name: %v, column: %#v", columnType.Name(), columnType)
 				}
 			case "name":
@@ -320,20 +328,35 @@ func TestMigrateColumns(t *testing.T) {
 				if !strings.Contains(strings.ToUpper(dataType), strings.ToUpper(columnType.DatabaseTypeName())) {
 					t.Fatalf("column name type should be correct, name: %v, length: %v, expects: %v, column: %#v", columnType.Name(), columnType.DatabaseTypeName(), dataType, columnType)
 				}
-				if length, ok := columnType.Length(); ((fullSupported && !sqlite) || ok) && length != 100 {
+				if length, ok := columnType.Length(); !sqlite && (!ok || length != 100) {
 					t.Fatalf("column name length should be correct, name: %v, length: %v, expects: %v, column: %#v", columnType.Name(), length, 100, columnType)
 				}
 			case "age":
-				if v, ok := columnType.DefaultValue(); (fullSupported || ok) && v != "18" {
+				if v, ok := columnType.DefaultValue(); !ok || v != "18" {
 					t.Fatalf("column age default value should be correct, name: %v, column: %#v", columnType.Name(), columnType)
 				}
-				if v, ok := columnType.Comment(); ((fullSupported && !sqlite && !sqlserver) || ok) && v != "my age" {
+				if v, ok := columnType.Comment(); !sqlite && !sqlserver && (!ok || v != "my age") {
 					t.Fatalf("column age comment should be correct, name: %v, column: %#v", columnType.Name(), columnType)
 				}
 			case "code":
-				if v, ok := columnType.Unique(); (fullSupported || ok) && !v {
+				if v, ok := columnType.Unique(); !ok || !v {
 					t.Fatalf("column code unique should be correct, name: %v, column: %#v", columnType.Name(), columnType)
 				}
+				if v, ok := columnType.DefaultValue(); !sqlserver && (!ok || v != "hello") {
+					t.Fatalf("column code default value should be correct, name: %v, column: %#v", columnType.Name(), columnType)
+				}
+				if v, ok := columnType.Comment(); !sqlite && !sqlserver && (!ok || v != "my code2") {
+					t.Fatalf("column code comment should be correct, name: %v, column: %#v", columnType.Name(), columnType)
+				}
+			case "code2":
+				if v, ok := columnType.Unique(); !sqlserver && (!ok || !v) {
+					t.Fatalf("column code2 unique should be correct, name: %v, column: %#v", columnType.Name(), columnType)
+				}
+			case "code3":
+				// TODO
+				// if v, ok := columnType.Unique(); !ok || v {
+				// 	t.Fatalf("column code unique should be correct, name: %v, column: %#v", columnType.Name(), columnType)
+				// }
 			}
 		}
 	}

--- a/tests/migrate_test.go
+++ b/tests/migrate_test.go
@@ -277,9 +277,15 @@ func TestMigrateIndexes(t *testing.T) {
 }
 
 func TestMigrateColumns(t *testing.T) {
+	fullSupported := map[string]bool{"sqlite": true, "mysql": true, "postgres": true, "sqlserver": true}[DB.Dialector.Name()]
+	sqlite := DB.Dialector.Name() == "sqlite"
+	sqlserver := DB.Dialector.Name() == "sqlserver"
+
 	type ColumnStruct struct {
 		gorm.Model
 		Name string
+		Age  int    `gorm:"default:18;comment:my age"`
+		Code string `gorm:"unique"`
 	}
 
 	DB.Migrator().DropTable(&ColumnStruct{})
@@ -304,10 +310,29 @@ func TestMigrateColumns(t *testing.T) {
 		stmt.Parse(&ColumnStruct2{})
 
 		for _, columnType := range columnTypes {
-			if columnType.Name() == "name" {
+			switch columnType.Name() {
+			case "id":
+				if v, ok := columnType.PrimaryKey(); (fullSupported || ok) && !v {
+					t.Fatalf("column id primary key should be correct, name: %v, column: %#v", columnType.Name(), columnType)
+				}
+			case "name":
 				dataType := DB.Dialector.DataTypeOf(stmt.Schema.LookUpField(columnType.Name()))
 				if !strings.Contains(strings.ToUpper(dataType), strings.ToUpper(columnType.DatabaseTypeName())) {
-					t.Errorf("column type should be correct, name: %v, length: %v, expects: %v", columnType.Name(), columnType.DatabaseTypeName(), dataType)
+					t.Fatalf("column name type should be correct, name: %v, length: %v, expects: %v, column: %#v", columnType.Name(), columnType.DatabaseTypeName(), dataType, columnType)
+				}
+				if length, ok := columnType.Length(); ((fullSupported && !sqlite) || ok) && length != 100 {
+					t.Fatalf("column name length should be correct, name: %v, length: %v, expects: %v, column: %#v", columnType.Name(), length, 100, columnType)
+				}
+			case "age":
+				if v, ok := columnType.DefaultValue(); (fullSupported || ok) && v != "18" {
+					t.Fatalf("column age default value should be correct, name: %v, column: %#v", columnType.Name(), columnType)
+				}
+				if v, ok := columnType.Comment(); ((fullSupported && !sqlite && !sqlserver) || ok) && v != "my age" {
+					t.Fatalf("column age comment should be correct, name: %v, column: %#v", columnType.Name(), columnType)
+				}
+			case "code":
+				if v, ok := columnType.Unique(); (fullSupported || ok) && !v {
+					t.Fatalf("column code unique should be correct, name: %v, column: %#v", columnType.Name(), columnType)
 				}
 			}
 		}

--- a/tests/prepared_stmt_test.go
+++ b/tests/prepared_stmt_test.go
@@ -2,6 +2,8 @@ package tests_test
 
 import (
 	"context"
+	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -87,4 +89,108 @@ func TestPreparedStmtFromTransaction(t *testing.T) {
 		t.Fatalf("Failed, got error: %v, rows affected: %v", result.Error, result.RowsAffected)
 	}
 	tx2.Commit()
+}
+
+func TestPreparedStmtDeadlock(t *testing.T) {
+	tx, err := OpenTestConnection()
+	AssertEqual(t, err, nil)
+
+	sqlDB, _ := tx.DB()
+	sqlDB.SetMaxOpenConns(1)
+
+	tx = tx.Session(&gorm.Session{PrepareStmt: true})
+
+	wg := sync.WaitGroup{}
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			user := User{Name: "jinzhu"}
+			tx.Create(&user)
+
+			var result User
+			tx.First(&result)
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+
+	conn, ok := tx.ConnPool.(*gorm.PreparedStmtDB)
+	AssertEqual(t, ok, true)
+	AssertEqual(t, len(conn.Stmts), 2)
+	for _, stmt := range conn.Stmts {
+		if stmt == nil {
+			t.Fatalf("stmt cannot bee nil")
+		}
+	}
+
+	AssertEqual(t, sqlDB.Stats().InUse, 0)
+}
+
+func TestPreparedStmtError(t *testing.T) {
+	tx, err := OpenTestConnection()
+	AssertEqual(t, err, nil)
+
+	sqlDB, _ := tx.DB()
+	sqlDB.SetMaxOpenConns(1)
+
+	tx = tx.Session(&gorm.Session{PrepareStmt: true})
+
+	wg := sync.WaitGroup{}
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			// err prepare
+			tag := Tag{Locale: "zh"}
+			tx.Table("users").Find(&tag)
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+
+	conn, ok := tx.ConnPool.(*gorm.PreparedStmtDB)
+	AssertEqual(t, ok, true)
+	AssertEqual(t, len(conn.Stmts), 0)
+	AssertEqual(t, sqlDB.Stats().InUse, 0)
+}
+
+func TestPreparedStmtInTransaction(t *testing.T) {
+	user := User{Name: "jinzhu"}
+
+	if err := DB.Transaction(func(tx *gorm.DB) error {
+		tx.Session(&gorm.Session{PrepareStmt: true}).Create(&user)
+		return errors.New("test")
+	}); err == nil {
+		t.Error(err)
+	}
+
+	var result User
+	if err := DB.First(&result, user.ID).Error; err == nil {
+		t.Errorf("Failed, got error: %v", err)
+	}
+}
+
+func TestPreparedStmtReset(t *testing.T) {
+	tx := DB.Session(&gorm.Session{PrepareStmt: true})
+
+	user := *GetUser("prepared_stmt_reset", Config{})
+	tx = tx.Create(&user)
+
+	pdb, ok := tx.ConnPool.(*gorm.PreparedStmtDB)
+	if !ok {
+		t.Fatalf("should assign PreparedStatement Manager back to database when using PrepareStmt mode")
+	}
+
+	pdb.Mux.Lock()
+	if len(pdb.Stmts) == 0 {
+		pdb.Mux.Unlock()
+		t.Fatalf("prepared stmt can not be empty")
+	}
+	pdb.Mux.Unlock()
+
+	pdb.Reset()
+	pdb.Mux.Lock()
+	defer pdb.Mux.Unlock()
+	if len(pdb.Stmts) != 0 {
+		t.Fatalf("prepared stmt should be empty")
+	}
 }

--- a/utils/tests/dummy_dialecter.go
+++ b/utils/tests/dummy_dialecter.go
@@ -8,6 +8,7 @@ import (
 )
 
 type DummyDialector struct {
+	TranslatedErr error
 }
 
 func (DummyDialector) Name() string {
@@ -42,4 +43,8 @@ func (DummyDialector) Explain(sql string, vars ...interface{}) string {
 
 func (DummyDialector) DataTypeOf(*schema.Field) string {
 	return ""
+}
+
+func (d DummyDialector) Translate(err error) error {
+	return d.TranslatedErr
 }


### PR DESCRIPTION
Cherry-pick upstream gorm commits for gorm.io/driver/postgres v1.5.0 and gorm.io/driver/mysql v1.3.2 compatibility                                                
                                                                                                                                                                    
  gorm.io/driver/postgres needs to be upgraded from v1.2.0 to v1.5.0 in tyk-pump (and storage) to fix CVE-2026-32286 — a high-severity DoS vulnerability in         
  jackc/pgx/v4 (all v4 versions affected, no patch available, EOL since July 2025). The fix requires migrating to pgx/v5, which is only pulled in by the postgres   
  driver v1.5.0+.           
                                                                                                                                                                    
  The newer postgres driver (and the consequently required mysql driver bump to v1.3.2) depend on gorm types/symbols that don't exist in our fork. This PR
  cherry-picks 6 upstream commits to add them:

  - 0af95f5 (go-gorm/gorm#5088) — migrator.ColumnType struct + enhanced gorm.ColumnType interface                                                                   
  - 1305f63 (go-gorm/gorm#5436) — gorm.Index interface + migrator.Index struct + GetIndexes() method
  - 85eaf9e (go-gorm/gorm#6004) — gorm.ErrDuplicatedKey + ErrorTranslator interface + error translation in AddError()                                               
  - 48ced75 — Fix PrimayKeyValue → PrimaryKeyValue typo in migrator.ColumnType                                                                                      
  - 5dd2bb4 (go-gorm/gorm#5782) — PreparedStmtDB.Reset() method                                                                                                     
  - 0df42e9 (go-gorm/gorm#4982) — DB.Connection() method for executing multiple commands in a single connection                                                     
                            
  Cherry-picking was chosen over a full rebase because the fork carries substantial Tyk-specific custom features (UseJSONTags, AutoEmbedd, raw_json data type,      
  helloeave/json marshaling) used across tyk-pump. These changes touch schema/field.go, schema/schema.go, and scan.go — files that have been heavily reworked
  upstream across ~280 commits, making a full rebase high-risk. The 6 cherry-picked commits touch different parts of the codebase (migrator, errors, interfaces,    
  finisher_api) with minimal overlap.                                               